### PR TITLE
Hotfix: django-allauth installation

### DIFF
--- a/scripts/scripts.d/25_allauth_install.sh
+++ b/scripts/scripts.d/25_allauth_install.sh
@@ -15,5 +15,5 @@ activate_virtualenv
 
 pip install $PIP_OPTIONS python-openid
 pip install $PIP_OPTIONS requests-oauthlib
-pip install $PIP_OPTIONS django-allauth #"django-allauth==0.40.0"
+pip install $PIP_OPTIONS django-allauth "django-allauth==0.40.0"
 pip install $PIP_OPTIONS django-countries #"django-countries==5.5"

--- a/scripts/scripts.d/25_allauth_install.sh
+++ b/scripts/scripts.d/25_allauth_install.sh
@@ -15,5 +15,5 @@ activate_virtualenv
 
 pip install $PIP_OPTIONS python-openid
 pip install $PIP_OPTIONS requests-oauthlib
-pip install $PIP_OPTIONS django-allauth "django-allauth==0.40.0"
+pip install $PIP_OPTIONS "django-allauth==0.40.0"
 pip install $PIP_OPTIONS django-countries #"django-countries==5.5"

--- a/scripts/scripts.d/30_eoxmagmod_sdist.sh
+++ b/scripts/scripts.d/30_eoxmagmod_sdist.sh
@@ -9,7 +9,7 @@
 . `dirname $0`/../lib_logging.sh
 . `dirname $0`/../lib_virtualenv.sh
 
-SOURCE_URL="https://github.com/ESA-VirES/MagneticModel/releases/download/eoxmagmod-0.9.6/eoxmagmod-0.9.6.tar.gz"
+SOURCE_URL="https://github.com/ESA-VirES/MagneticModel/releases/download/eoxmagmod-0.9.7/eoxmagmod-0.9.7.tar.gz"
 
 info "Installing EOxMagMod from source disribution package ..."
 


### PR DESCRIPTION
Fixes `django-allauth` installation.
Required by https://github.com/ESA-VirES/VirES-Server/pull/138